### PR TITLE
entz-playground: no more "null"

### DIFF
--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -135,14 +135,14 @@
         var xhr = new XMLHttpRequest()
         xhr.open("POST", "/submit")
         xhr.setRequestHeader("Content-Type", "application/json")
-        xhr.send(`
-{
-   "subject": "${subject}",
-   "action": "${action}",
-   "resource": "${resource}",
-   "body": "${body}"
-}
-`)
+
+        obj = {}
+        if (subject  != null) {obj["subject"]  = subject}
+        if (action   != null) {obj["action"]   = action}
+        if (resource != null) {obj["resource"] = resource}
+        if (body     != null) {obj["body"]     = body}
+
+        xhr.send(JSON.stringify(obj))
 
         // This nested function stuff is needed because other wise the
         // user-provided data dosen't make it to the inside of the
@@ -203,6 +203,11 @@
         var action = document.getElementById("actionInput").value
         var resource = document.getElementById("resourceInput").value
         var body = document.getElementById("bodyInput").value
+
+        if (subject  == "") {subject  = null}
+        if (action   == "") {action   = null}
+        if (resource == "") {resource = null}
+        if (body     == "") {body     = null}
 
         getDecision(subject, action, resource, body, function(code, data, user) {
 

--- a/go-sample/playground/opa.go
+++ b/go-sample/playground/opa.go
@@ -123,15 +123,27 @@ func response(input *FormInput) (interface{}, bool, error) {
 		}{"OPA is not configured, all operations are allowed."}, true, nil
 	}
 
-	// TODO: what to do with Body?
+	inputMap := map[string]interface{}{}
+
+	if input.Resource != nil {
+		inputMap["resource"] = *input.Resource
+	}
+
+	if input.Subject != nil {
+		inputMap["subject"] = *input.Subject
+	}
+
+	if input.Action != nil {
+		inputMap["action"] = *input.Action
+	}
+
+	if input.Body != nil {
+		inputMap["body"] = *input.Body
+	}
 
 	decOpts := sdk.DecisionOptions{
-		Path: rulePath,
-		Input: map[string]interface{}{
-			"resource": input.Resource,
-			"subject":  input.Subject,
-			"action":   input.Action,
-		},
+		Path:  rulePath,
+		Input: inputMap,
 	}
 
 	result, err := opa.Decision(opaContext, decOpts)

--- a/go-sample/playground/server.go
+++ b/go-sample/playground/server.go
@@ -26,10 +26,10 @@ import (
 var indexHTMLFile string
 
 type FormInput struct {
-	Subject  string
-	Action   string
-	Resource string
-	Body     string
+	Subject  *string
+	Action   *string
+	Resource *string
+	Body     *string
 }
 
 func jsonError(w http.ResponseWriter, message string, code int) {


### PR DESCRIPTION
Button-related decisions in the entz playground will no longer use the
string literal "null" for the action and subject, instead those fields
will be omitted entirely.

Additionally, requests entered via the input form will have omitted
fields removed from the request, rather than having those fields show up
as the empty string.

STY-10871