### PR TITLE
playground: add policy toggle, watch all by default

### DIFF
--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -374,6 +374,8 @@
             }, node)
         }
 
+        control_allowed = document.getElementById("allow_das_control").checked
+
         // We also want the 'remove', 'copy', and 'sample' buttons to be
         // able to be enabled and disabled by policies.
         //
@@ -396,43 +398,61 @@
         // entitlements.
 
         // sample buttons
-        getDecision(null, null, "/entz-playground/buttons/samples", null, function (code, data, user) {
-                if (code >= 400) {
-                    user.innerHTML = "ERROR"
-                    console.log(`got error code ${code}, result was: `, data)
-                    return
-                }
-                var buttons = document.getElementsByClassName("sample_button")
-                for (var i = 0 ; i < buttons.length; i++) {
-                    buttons[i].disabled = !data.allowed
-                }
-        }, null)
+        if (control_allowed) {
+            getDecision(null, null, "/entz-playground/buttons/samples", null, function (code, data, user) {
+                    if (code >= 400) {
+                        user.innerHTML = "ERROR"
+                        console.log(`got error code ${code}, result was: `, data)
+                        return
+                    }
+                    var buttons = document.getElementsByClassName("sample_button")
+                    for (var i = 0 ; i < buttons.length; i++) {
+                        buttons[i].disabled = !data.allowed
+                    }
+            }, null)
 
-        // copy buttons
-        getDecision(null, null, "/entz-playground/buttons/copy", null, function (code, data, user) {
-                if (code >= 400) {
-                    user.innerHTML = "ERROR"
-                    console.log(`got error code ${code}, result was: `, data)
-                    return
-                }
-                var buttons = document.getElementsByClassName("copy_button")
-                for (var i = 0 ; i < buttons.length; i++) {
-                    buttons[i].disabled = !data.allowed
-                }
-        }, null)
+            // copy buttons
+            getDecision(null, null, "/entz-playground/buttons/copy", null, function (code, data, user) {
+                    if (code >= 400) {
+                        user.innerHTML = "ERROR"
+                        console.log(`got error code ${code}, result was: `, data)
+                        return
+                    }
+                    var buttons = document.getElementsByClassName("copy_button")
+                    for (var i = 0 ; i < buttons.length; i++) {
+                        buttons[i].disabled = !data.allowed
+                    }
+            }, null)
 
-        // remove buttons
-        getDecision(null, null, "/entz-playground/buttons/remove", null, function (code, data, user) {
-                if (code >= 400) {
-                    user.innerHTML = "ERROR"
-                    console.log(`got error code ${code}, result was: `, data)
-                    return
-                }
-                var buttons = document.getElementsByClassName("remove_button")
-                for (var i = 0 ; i < buttons.length; i++) {
-                    buttons[i].disabled = !data.allowed
-                }
-        }, null)
+            // remove buttons
+            getDecision(null, null, "/entz-playground/buttons/remove", null, function (code, data, user) {
+                    if (code >= 400) {
+                        user.innerHTML = "ERROR"
+                        console.log(`got error code ${code}, result was: `, data)
+                        return
+                    }
+                    var buttons = document.getElementsByClassName("remove_button")
+                    for (var i = 0 ; i < buttons.length; i++) {
+                        buttons[i].disabled = !data.allowed
+                    }
+            }, null)
+
+        } else {
+            var buttons = document.getElementsByClassName("sample_button")
+            for (var i = 0 ; i < buttons.length; i++) {
+                buttons[i].disabled = false
+            }
+
+            var buttons = document.getElementsByClassName("copy_button")
+            for (var i = 0 ; i < buttons.length; i++) {
+                buttons[i].disabled = false
+            }
+
+            var buttons = document.getElementsByClassName("remove_button")
+            for (var i = 0 ; i < buttons.length; i++) {
+                buttons[i].disabled = false
+            }
+        }
 
         // update the bundle timestamp
         bundle_timestamp(function(ts) {
@@ -480,6 +500,10 @@
     setTimeout(() => {
         timeUpdater()
     }, 2000);
+
+    setTimeout(() => {
+        onWatchAllSamples()
+    }, 500);
 </script>
 
 <h1>Entitlements Playground</h1>
@@ -501,10 +525,11 @@
     from the DAS. The <b>Remove</b> button will delete the row from the
     table.</p>
 
-    <p>The sample buttons above the form, and the <b>Copy</b> and <b>Remove</b>
-    buttons for each row in the <b>Watching</b> table are controlled by
-    Entitlements policies. Each group of buttons can be enabled or disabled by
-    creating a policy to allow or deny access to the
+    <p>When "Allow DAS policy to control buttons" is checked, the sample
+    buttons above the form, and the <b>Copy</b> and <b>Remove</b> buttons for
+    each row in the <b>Watching</b> table are controlled by Entitlements
+    policies. Each group of buttons can be enabled or disabled by creating a
+    policy to allow or deny access to the
     <code>/entz-playground/buttons/samples</code>,
     <code>/entz-playground/buttons/copy</code>, or
     <code>/entz-playground/buttons/remove</code> respectively. </p>
@@ -512,6 +537,8 @@
     <p><b>TIP:</b>Because the DAS has a default-deny policy, these buttons will
     be disabled until you create a policy in your DAS that allows them.</p>
 
+    <input type="checkbox" id="allow_das_control" onclick="onBundleChange()">Allow DAS policy to control
+    buttons.</input>
 
     <h2>Request Entry</h2>
     <div id="requestEntry">
@@ -527,7 +554,6 @@
         <button type="button" onclick="onSubmit()">Submit</button>
         <button type="button" onclick="onClear()">Clear Form</button>
         <button type="button" onclick="onWatch()">Watch</button>
-        <button type="button" onclick="onWatchAllSamples()">Watch All Samples</button>
     </div>
 
 <div id="results"></div>


### PR DESCRIPTION
To improve the usability of the playground, this commit makes 2 changes:

1. All samples are watched by default and the "watch all" button has
   been removed. Hopefully this will make it clearer what the purpose of
   the "Watching" table is.

2. A new toggle has been allowed to enable/disable DAS control over
   buttons, which is unchecked by default. This way the user cannot get
   themselves into a state where buttons are disabled without a manual
   action on their part.

STY-11057