### PR TITLE
playground errata

### DIFF
--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -356,7 +356,7 @@
                   var curlDataString = JSON.stringify(curlData, null, null)
                   var curlCommandText = `curl -LSs -H "Content-Type: application/json" -X POST --data '${curlDataString}' http://localhost:8181/v1/data/main/main`;
                   var curlCommandTextEncoded = curlCommandText.replace(/"/g, '\22').replace(/'/g, '\27');
-                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<br /><code>${curlCommandText}</code></p><button class=copy_btn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
+                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<br /><code>${curlCommandText}</code></p><button class=copy_btn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy Command</button>`
                   node.appendChild(curlCommand)
                   node.appendChild(respCode)
                 })

--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -356,7 +356,7 @@
                   var curlDataString = JSON.stringify(curlData, null, null)
                   var curlCommandText = `curl -LSs -H "Content-Type: application/json" -X POST --data '${curlDataString}' http://localhost:8181/v1/data/main/main`;
                   var curlCommandTextEncoded = curlCommandText.replace(/"/g, '\22').replace(/'/g, '\27');
-                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<br /><code>${curlCommandText}</code></p><button class=copy_bttn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
+                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<br /><code>${curlCommandText}</code></p><button class=copy_btn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
                   node.appendChild(curlCommand)
                   node.appendChild(respCode)
                 })
@@ -833,7 +833,7 @@
     width: 33px;
   }
 
-  .copy_bttn {
+  .copy_btn {
     text-align: center;
     height: 35px;
     width: 52px;

--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -859,8 +859,8 @@
         experiment with different requests using the Entitlements object model.
         The interface is pre-populated with a few examples. You can click the
         '&gt;' symbol next to any request to see the corresponding response
-        from OPA. You can use "Edit" to modify a request in-place, or "Copy" to
-        create a new one based on an existing one.
+        from OPA. Use <b>Edit</b> to modify a request in-place, or <b>Copy</b> to
+        create a new request from an existing one.
         </p>
 
         <p>When "Allow DAS policy to control buttons" is checked, the

--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -356,7 +356,7 @@
                   var curlDataString = JSON.stringify(curlData, null, null)
                   var curlCommandText = `curl -LSs -H "Content-Type: application/json" -X POST --data '${curlDataString}' http://localhost:8181/v1/data/main/main`;
                   var curlCommandTextEncoded = curlCommandText.replace(/"/g, '\22').replace(/'/g, '\27');
-                  curlCommand.innerHTML = `<p class=curl_command>Equivelant curl command (for use with local OPA):<code>${curlCommandText}</code></p><button class=copy_bttn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
+                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<code>${curlCommandText}</code></p><button class=copy_bttn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
                   node.appendChild(curlCommand)
                   node.appendChild(respCode)
                 })

--- a/go-sample/playground/index.html
+++ b/go-sample/playground/index.html
@@ -356,7 +356,7 @@
                   var curlDataString = JSON.stringify(curlData, null, null)
                   var curlCommandText = `curl -LSs -H "Content-Type: application/json" -X POST --data '${curlDataString}' http://localhost:8181/v1/data/main/main`;
                   var curlCommandTextEncoded = curlCommandText.replace(/"/g, '\22').replace(/'/g, '\27');
-                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<code>${curlCommandText}</code></p><button class=copy_bttn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
+                  curlCommand.innerHTML = `<p class=curl_command>Equivalent curl command (for use with local OPA):<br /><code>${curlCommandText}</code></p><button class=copy_bttn type="button" onclick="copyCurlCommand('${curlCommandTextEncoded}')">Copy</button>`
                   node.appendChild(curlCommand)
                   node.appendChild(respCode)
                 })


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Playground needs a bit of cleanup.

<img width="869" alt="image" src="https://user-images.githubusercontent.com/6817500/205354446-e72b9ce0-9070-49a1-9ee3-27a09c461969.png">

<img width="715" alt="image" src="https://user-images.githubusercontent.com/6817500/205354598-09572cb4-4ed4-469e-b45b-9cde98b2d0e5.png">


### :+1: Definition of done

(1) Fix typo
(2) Add line break
(3) Rename <btn>Copy</btn> to <btn>Copy Command</btn> to distinguish the two types.
(4) Use consistent typographic style.

### :athletic_shoe: How to test

🤷 

### :chains: Related Resources

STY-n/a
